### PR TITLE
Expand Forbidden Titles list to prevent panics from failed 120hz patches

### DIFF
--- a/patch-server/server_patch.cpp
+++ b/patch-server/server_patch.cpp
@@ -91,6 +91,7 @@ static bool is_forbidden_titleid(const uint32_t name)
         case sid("NPXS40093"):  // common dialog, SceCdlgApp ps5
         case sid("NPXS21016"):  // SceSpZeroConf ps4
         case sid("NPXS40112"):  // SceSpZeroConf ps5
+        case sid("NPXS40146"):  // SceShareVideoTranscoder ps5
             // case sid("CUSA00960"):  // Vue
             {
                 return true;

--- a/patch-server/server_patch.cpp
+++ b/patch-server/server_patch.cpp
@@ -92,6 +92,7 @@ static bool is_forbidden_titleid(const uint32_t name)
         case sid("NPXS21016"):  // SceSpZeroConf ps4
         case sid("NPXS40112"):  // SceSpZeroConf ps5
         case sid("NPXS40146"):  // SceShareVideoTranscoder ps5
+        case sid("NPXS40039"):  // SceVideoCore2K ps5
             // case sid("CUSA00960"):  // Vue
             {
                 return true;

--- a/patch-server/server_patch.cpp
+++ b/patch-server/server_patch.cpp
@@ -93,6 +93,7 @@ static bool is_forbidden_titleid(const uint32_t name)
         case sid("NPXS40112"):  // SceSpZeroConf ps5
         case sid("NPXS40146"):  // SceShareVideoTranscoder ps5
         case sid("NPXS40039"):  // SceVideoCore2K ps5
+        case sid("NPXS40102"):  // SceRemotePlay ps5
             // case sid("CUSA00960"):  // Vue
             {
                 return true;


### PR DESCRIPTION
I have been tracing a number of kernel panics to ps-patch-system's 120hz patch attempting and failing to patch system titles. The following are the titles I have found to be problematic and when. PR adds these titles to the forbidden title list to prevent panics.

1. SceShareVideoTranscoder -- Patch is attempted when trophy is earned and clip is saved.
2. SceVideoCore2K -- Patch is attempted when browsing media gallery
3. SceRemotePlay -- Patch is attempted when accessing Remote Play