### PR TITLE
Made the browser popup on injection optional

### DIFF
--- a/patch-server/patch_web_xml.cpp
+++ b/patch-server/patch_web_xml.cpp
@@ -122,9 +122,9 @@ std::string get_settings_field_string(const fs::path& settings_file,
     return get_settings_field_raw(settings_file, field, default_value);
 }
 
-static bool get_root_settings_bool(const char* name)
+static bool get_root_settings_bool(const char* name, const bool default_value = false)
 {
-    return get_settings_field_bool(ROOT_XML_PATH, name);
+    return get_settings_field_bool(ROOT_XML_PATH, name, default_value);
 }
 
 bool apply_patch_diagnostic_enabled()
@@ -139,5 +139,5 @@ bool apply_120hz_enabled()
 
 bool pop_up_browser_enabled()
 {
-    return get_root_settings_bool("pop_up_browser");
+    return get_root_settings_bool("pop_up_browser", true);
 }

--- a/patch-server/patch_web_xml.cpp
+++ b/patch-server/patch_web_xml.cpp
@@ -136,3 +136,8 @@ bool apply_120hz_enabled()
 {
     return get_root_settings_bool("apply_120hz_videoout");
 }
+
+bool pop_up_browser_enabled()
+{
+    return get_root_settings_bool("pop_up_browser");
+}

--- a/patch-server/patch_web_xml.hpp
+++ b/patch-server/patch_web_xml.hpp
@@ -45,3 +45,4 @@ std::string get_settings_field_string(const fs::path& settings_file,
                                       const std::string& default_value = "");
 bool apply_patch_diagnostic_enabled();
 bool apply_120hz_enabled();
+bool pop_up_browser_enabled();

--- a/patch-web/main.cpp
+++ b/patch-web/main.cpp
@@ -1224,6 +1224,7 @@ struct patch_web_context
     {
         add_setting("apply_patch_diagnostic", "Patch Diagnostic", "Enable verbose notification during patching process", SettingType::Bool, "0");
         add_setting("apply_120hz_videoout", "Patch VideoOut for 120hz", "Patches libSceVideoOut for 120hz", SettingType::Bool, "0");
+        add_setting("pop_up_browser", "Pop Up Browser", "Automatically opens the browser when injecting the payload", SettingType::Bool, "1");
     }
 
     void run(const std::string& root, int p)
@@ -1270,7 +1271,7 @@ struct patch_web_context
             snprintf(url, _countof_1(url), "http://127.0.0.1:%d", port);
             notify(ELF_NAME ": serving at %s, xml root %s\n", url, root.c_str());
             static bool shown = false;
-            if (!shown)
+            if (!shown && pop_up_browser_enabled())
             {
                 sceUserServiceInitialize(0);
                 sceSystemServiceLaunchWebBrowser(url, 0);


### PR DESCRIPTION
Added a `Pop Up Browser` setting that is enabled by default.
Toggling the option hides the browser window that pops up when injecting the payload.

I also noted that the default values are not respected when using `get_root_settings_bool()`, so I added a quick fix for it in the 2nd commit. Ideally the value that is passed in `add_setting()` will be returned instead, but that was too out of scope for what I wanted to do and would rather keep the changes minimal.

<img width="1335" height="123" alt="image" src="https://github.com/user-attachments/assets/2db53cb3-0fe7-4d0b-a5c5-56cbacd64cca" />

Feel free to edit the title/description strings of course, I just used what seemed good enough to me.

**Thank you for the awesome work, illusionyy!**